### PR TITLE
Remove console.dir() call on writeFile

### DIFF
--- a/lib/express-session-json.js
+++ b/lib/express-session-json.js
@@ -32,7 +32,6 @@ module.exports = function(session) {
         sess._sessionid = sid;
         this._sessions[sid] = sess;
         fs.writeFile(this._filename, JSON.stringify(this._sessions), function(err) {
-            console.dir(arguments);
             fn(err, sess);    
         });
         


### PR DESCRIPTION
It keeps continuosly logging and object to stdout  . Could it be replaced by a call to debug() from the [debug package](https://www.npmjs.org/package/debug) ?
