### PR TITLE
Fix .destroy() not calling callback

### DIFF
--- a/lib/express-session-json.js
+++ b/lib/express-session-json.js
@@ -46,8 +46,11 @@ module.exports = function(session) {
     };
 
     JsonStore.prototype.destroy = function(sid, fn) {
-        if (!this._sessions || !this._sessions[sid])
+        if (!this._sessions || !this._sessions[sid]) {
+            fn();
             return;
+        }
+        
         delete this._sessions[sid];
 
         // no big matter if have failed


### PR DESCRIPTION
`JsonStore.prototype.destroy()` should call the given callback even if there were no sessions to destroy.

Because the callback wasn't called in case when there were no session to destroy, the below code never sent response to the client:

```
app.delete('/logout', function(req, res) {
    req.session.destroy(function() {
        res.send('{}');
    });
});
```

The above callback gets called, but when `express-session` overwrites `res.end()` method it also calls `store.destroy()` again ( https://github.com/expressjs/session/blob/master/index.js#L250 ) and this time this callback never gets sent.
